### PR TITLE
Archivematica export plugin for eprints

### DIFF
--- a/cfg/cfg.d/z_archivematica.pl
+++ b/cfg/cfg.d/z_archivematica.pl
@@ -7,6 +7,9 @@
 use EPrints::DataObj::Archivematica;
 
 # Enable plugins
+$c->{plugins}{"Screen::EPrint::Staff::Archivematica"}{params}{disable} = 0;
+$c->{plugins}{"Screen::Archivematica::Export"}{params}{disable} = 0;
+
 $c->{plugins}{"Export::Archivematica"}{params}{disable} = 0;
 $c->{plugins}{"Export::Archivematica::EPrint"}{params}{disable} = 0;
 
@@ -17,7 +20,13 @@ $c->{datasets}->{archivematica} = {
 };
 
 # Set user roles (edit not allowed as should only be updated by EPrints and export results
-push @{$c->{user_roles}->{admin}}, qw{ +archivematica/view +archivematica/destroy };
+push @{$c->{user_roles}->{admin}}, qw{ +archivematica/view +archivematica/destroy archive/eprint archivematica/export };
+
+# Set archivematica transfer location
+$c->{archivematica}->{path} = $c->{archiveroot}.'/archivematica';
+
+# Include Derivatives?
+$c->{DPExport}->{include_derivatives} = 0;
 
 $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_AFTER_COMMIT, sub
 {

--- a/lib/lang/en/phrases/z_archivematica.xml
+++ b/lib/lang/en/phrases/z_archivematica.xml
@@ -8,11 +8,17 @@
 <epp:phrase id="archivematica_fieldname_amid">Archivematica ID</epp:phrase>
 <epp:phrase id="archivematica_fieldname_datasetid">Dataset</epp:phrase>
 <epp:phrase id="archivematica_fieldname_dataobjid">Object ID</epp:phrase>
+<epp:phrase id="archivematica_fieldname_uuid">Archivematica UUID</epp:phrase>
 <epp:phrase id="archivematica_fieldname_result_log">Log</epp:phrase>
 <epp:phrase id="archivematica_fieldname_result_log_result">Result</epp:phrase>
 <epp:phrase id="archivematica_fieldname_result_log_timestamp">Timestamp</epp:phrase>
 <epp:phrase id="archivematica_fieldname_result_log_action">Action</epp:phrase>
-
 <epp:phrase id="archivematica_fieldname_is_dirty">New Transfer Pending</epp:phrase>
+
+<epp:phrase id="Plugin/Screen/EPrint/Staff/Archivematica:action:create_archivematica_record:title">Archivematica Transfer</epp:phrase> 
+<epp:phrase id="Plugin/Screen/EPrint/Staff/Archivematica:action:create_archivematica_record:description">Archive this item via Archivematica</epp:phrase>
+<epp:phrase id="Plugin/Screen/EPrint/Staff/Archivematica:create_transfer">A request to archive this item via Archivematica has been made.</epp:phrase>
+
+<epp:phrase id="Plugin/Screen/Archivematica/Export:action:export:title">Export</epp:phrase>
 
 </epp:phrases>

--- a/lib/plugins/EPrints/DataObj/Archivematica.pm
+++ b/lib/plugins/EPrints/DataObj/Archivematica.pm
@@ -18,6 +18,7 @@ sub get_system_field_info
 		{ name => "amid", type => "counter", sql_counter => "archivematica", sql_index => 1 },
 		{ name => "datasetid", type => "id", required => 1, sql_index => 1 },
 		{ name => "dataobjid", type => "id", required => 1, sql_index => 1 },
+		{ name => "uuid", type => "int", sql_index => 1 },
 		{ 
 			name => "result_log",
 		  	type => "compound",
@@ -29,9 +30,17 @@ sub get_system_field_info
         		],
 		},
 		{ name => "is_dirty", type => "boolean", } # used to record whether or not a new Archivematica transfer needs to be created for this record
-  );
+	);
 }
 
+sub get_dataobj
+{
+	my( $self ) = @_;
+
+	my $session = $self->{session};
+	my $ds = $session->dataset( $self->value( "datasetid" ) );
+	return $ds->dataobj( $self->value( "dataobjid" ) );
+}
 
 sub add_to_record_log
 {

--- a/lib/plugins/EPrints/Plugin/Export/Archivematica.pm
+++ b/lib/plugins/EPrints/Plugin/Export/Archivematica.pm
@@ -23,4 +23,10 @@ sub new
 	return $class->SUPER::new( %params );
 }
 
+sub output_dataobj
+{
+	my ($self, $dataobj, %opts) = @_;
+
+}
+
 1;

--- a/lib/plugins/EPrints/Plugin/Export/Archivematica/EPrint.pm
+++ b/lib/plugins/EPrints/Plugin/Export/Archivematica/EPrint.pm
@@ -7,6 +7,8 @@ EPrints::Plugin::Export::Archivematica::EPrint
 package EPrints::Plugin::Export::Archivematica::EPrint;
 
 use EPrints::Plugin::Export::Archivematica;
+use File::Copy;
+use Digest::MD5 qw(md5_hex);
 
 @ISA = ( "EPrints::Plugin::Export::Archivematica" );
 
@@ -29,16 +31,186 @@ sub output_dataobj
 {
 	my( $self, $dataobj, %opts ) = @_;
 
-	## To Do ##
-	# Create directories in temporary location and 
-	# populate with documents, XML, checksums, etc.
-	# to generate an Archivematica transfer.
-	#
-	# Should record a result code, to be stored in 
-	# the Archivematica record log for this DataObj
-	#
-	# Returns a tar.gz when successful
+	my $session = $self->{session};
 
+	my $amid = $opts{amid};
+
+	# create directory to store exported files
+	my $target_path = $session->config( "archivematica", "path" ) . "/$amid";
+	my $objects_path = "$target_path/objects";
+	my $metadata_path = "$target_path/metdadata";	
+
+	### objects
+	$self->_make_dir( $objects_path );
+
+	## documents
+	my $documents_path = "$objects_path/documents";
+	$self->_make_dir( $documents_path );
+	
+	# get the main, non-volatile documents
+	my @docs = $dataobj->get_all_documents;
+	foreach my $doc ( @docs )
+	{
+		# create a directory for each doc
+		my $doc_path= "$documents_path/documentid-" . $doc->id; 
+		$self->_make_dir( $doc_path );
+
+		# and create a files directory in the doc directory
+		my $files_path = "$doc_path/files";
+		$self->_make_dir( $files_path );
+
+		# and then create a file directory for each file
+		foreach my $file ( @{$doc->get_value( "files" )} )
+		{
+			my $file_path = "$files_path/" . $file->id;
+			$self->_make_dir( $file_path );
+		
+			# and copy the file into the new file dir
+			my $filename = $file->get_value( "filename" );
+			my $local_path = $doc->local_path . "/" . $filename;
+			copy($local_path, "$file_path/$filename") or die "Copy failed: $!";
+		}
+	}
+
+	## derivatives
+	if( $session->config( 'DPExport', 'include_derivatives' ) ) # only include derivatives if enabled
+	{
+		my $derivatives_path = "$objects_path/derivatives";
+		$self->_make_dir( $derivatives_path );
+
+		# get the volatile documents
+		@docs = @{$dataobj->get_value( "documents" )};
+		foreach my $doc ( @docs )
+		{
+			next unless $doc->has_relation( undef, "isVolatileVersionOf" );
+
+			# and create a files directory in the doc directory
+			my $pos = $doc->get_value( "pos" );
+	                my $pos_path = "$derivatives_path/$pos";
+			$self->_make_dir( $pos_path );
+
+			# and then copy the files into the pos directory
+        	        foreach my $file ( @{$doc->get_value( "files" )} )
+                	{
+	                        my $filename = $file->get_value( "filename" );
+        	                my $file_path = $doc->local_path . "/" . $filename;
+                	        copy($file_path, "$pos_path/$filename") or die "Copy failed: $!";
+	                }
+		}
+	}
+
+	### metadata
+	$self->_make_dir( $metadata_path );
+
+	## ep3.xml
+	my $xml = $session->xml;
+        my $doc = $xml->parse_string( $dataobj->export( "XML" ) );
+	EPrints::XML::write_xml_file( $doc, "$metadata_path/EP3.xml" );
+
+	
+	## revisions 
+	# create a directory to copy the revisions to
+	my $revisions_path = "$metadata_path/revisions";
+	$self->_make_dir( $revisions_path);
+
+	# now copy the actual revisions
+	my $eprint_revisions_path = $dataobj->local_path . "/revisions";
+	opendir my $eprint_revisions_dir, "$eprint_revisions_path" or die "Cannot open directory: $!";
+	my @revisions = readdir $eprint_revisions_dir;
+	foreach my $revision ( @revisions )
+	{
+		if( $revision =~ /^[\d]+\.xml$/ )
+		{
+			copy("$eprint_revisions_path/$revision", "$revisions_path/$revision") or die "Copy failed: $!";
+		}
+	}
+
+	## Dublin Core JSON
+	# first get the generic DC export plugin and use it to get an array of data
+        my $dc_export = $session->plugin( "Export::DC" );
+	my $dc_metadata = $dc_export->convert_dataobj( $dataobj );
+
+	# and then convert it into JSON by creating a hash of data and passing that to do the JSON export plugin
+	my $epdata = {};
+	foreach my $metadata ( @{$dc_metadata} )
+        {
+		my $key = $metadata->[0];
+		my $value = $metadata->[1];
+		if( exists $epdata->{$key} ) # more than one entry for this key, turn value into an array
+		{
+			my @new_values;
+			push @new_values, $epdata->{$key};
+			push @new_values, $value;
+			$epdata->{$key} = \@new_values;
+		}
+		else 
+		{
+	        	$epdata->{$key} = $value;        
+		}
+	}
+	my $json_export = $session->plugin( "Export::JSON" );
+	my $json = $json_export->output_dataobj( $epdata );
+
+	# now write the resulting json to file
+	my $dc_file_path = "$metadata_path/metadata.json";
+	open(my $fh, '>', $dc_file_path) or die "Could not open file '$dc_file_path' $!";
+	print $fh $json;
+	close $fh;
+
+	## Checksum manifest
+	# get all the files from the objects directory
+	my @file_paths;
+	$self->_read_dir( $objects_path, \@file_paths );
+	
+	# set up the manifest file
+	my $manifest_file_path = "$metadata_path/checksum.md5";
+	open(my $manifest_fh, '>', $manifest_file_path) or die "Could not open file '$manifest_file_path' $!";
+	
+	# loop through the files in the objects dir and add them to manifest
+	foreach my $file_path ( @file_paths )
+	{
+		open(my $fh, '<', $file_path) or die "Could not open file '$file_path' $!";
+		my $ctx = Digest::MD5->new;
+		$ctx->addfile( $fh );
+		my $digest = $ctx->hexdigest;
+		close $fh;
+		print $manifest_fh $digest . " " . $file_path . "\n";
+	}
+	close $manifest_fh;
+}	
+
+sub _make_dir
+{
+	my( $self, $dir ) = @_;
+
+	unless( -d $dir )
+        {
+                EPrints::Platform::mkdir( $dir );
+        }
+
+}
+
+sub _read_dir
+{
+	my( $self, $path, $file_paths ) = @_;
+
+	if( -d $path ) # we have a directory
+	{
+		opendir my $dir, "$path" or die "Cannot open directory: $!";
+		my @contents = readdir $dir;
+		closedir $dir;
+		foreach my $item ( @contents )
+		{
+			next if( $item eq "." || $item eq "..");
+
+			$self->_read_dir( "$path/$item", $file_paths );
+		}
+	}
+	elsif( -f $path ) # we have a file
+	{
+		push @$file_paths, $path;
+		return $file_paths;
+	}	
 }
 
 1;


### PR DESCRIPTION
Initial work on the export plugin that can be used to create an Archivematica transfer. This plugin is currently called via 'Manage records' --> 'Archivematica' and then clicking the 'Export' button for the relevant Archivematica record (Archivematica records can be created via an EPrint's 'Actions' tab). The plugin can then later be integrated with the triggers when ready.

