### PR TITLE
Updated make_ingredient.sh

### DIFF
--- a/make_ingredient.sh
+++ b/make_ingredient.sh
@@ -1,24 +1,17 @@
 #!/bin/bash
 
-# Copy the contents into the structure used by an EPrints 3.4 ingredient.
+# Add a symlink to make this repo a valid EPrints 3.4 ingredient.
 
-# run ./make_ingredient.sh
-# then place ingredients/archivematica under your EPrints 3.4 ingredients directory
-# update your flavours/pub_lib/inc file to include ingredients/archivematica
-# run epadmin update REPO
+# check out this git repo in ingredients/
+# run ./make_ingredient.sh from ingredients/EPrintsArchivematicia
+# update your flavours/pub_lib/inc file to include ingredients/EPrintsArchivematicia
+# run epadmin update [REPONAME]
 # apachectl graceful
 
-I=ingredients/archivematica
-mkdir -p $I
-
-cp -r bin $I
-cp -r cgi $I
-
-cp -r cfg/cfg.d $I
-# cp -r cfg/citations $I # unused?
-
-cp -r lib/citations $I
-cp -r lib/static $I
-cp -r lib/lang $I
-cp -r lib/plugins $I
-cp -r lib/workflows $I
+ln -s cfg/cfg.d 
+# ln -s cfg/citations # unused?
+ln -s lib/citations
+ln -s lib/static
+ln -s lib/lang
+ln -s lib/plugins
+ln -s lib/workflows


### PR DESCRIPTION
So we can make this repo an ingredient in-situ, like other EPMs (eg IRstats2).

The primary advantage is that the ingredient then remains under source control. The previous mechanism of copying files removes the files from git.